### PR TITLE
Fix SEO error when saving temporarily by disabling localized fields

### DIFF
--- a/demo/package.json
+++ b/demo/package.json
@@ -13,7 +13,7 @@
     "generate:types": "cross-env PAYLOAD_CONFIG_PATH=src/payload.config.ts payload generate:types"
   },
   "dependencies": {
-    "payload": "^0.17.0",
+    "payload": "^0.17.1",
     "dotenv": "^8.2.0",
     "express": "^4.17.1"
   },

--- a/demo/yarn.lock
+++ b/demo/yarn.lock
@@ -7316,10 +7316,10 @@ pause@0.0.1:
   resolved "https://registry.yarnpkg.com/pause/-/pause-0.0.1.tgz#1d408b3fdb76923b9543d96fb4c9dfd535d9cb5d"
   integrity sha1-HUCLP9t2kjuVQ9lvtMnf1TXZy10=
 
-payload@^0.17.0:
-  version "0.17.0"
-  resolved "https://registry.yarnpkg.com/payload/-/payload-0.17.0.tgz#192a44588b2bb98f16b10726544bd81cc0b19137"
-  integrity sha512-+UlgCoAUv44e2ehGN0qWBd/m0FulGSdvpupDScL4KNZjF1GXyXJeWHpZ+Su6+BGrweWlhp+0W1Ym7Fus8OMnYg==
+payload@^0.17.1:
+  version "0.17.1"
+  resolved "https://registry.yarnpkg.com/payload/-/payload-0.17.1.tgz#a0926feba7b60b00cb02ec307a432c676e082ed9"
+  integrity sha512-W1bOFu6ZF6TQ/yomeO4rGX03wKZtwxANhvgVwTPxO16q/Axm/Fap9F1l+o7zp56mHIi10au7eB+o07cOLwDaAA==
   dependencies:
     "@babel/cli" "^7.12.8"
     "@babel/core" "^7.11.6"

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   "devDependencies": {
     "@types/react": "^18.0.8",
     "@types/react-dom": "^18.0.3",
-    "payload": "^0.17.0",
+    "payload": "^0.17.1",
     "react": "^18.0.0",
     "typescript": "^4.5.5"
   },

--- a/src/index.ts
+++ b/src/index.ts
@@ -27,7 +27,7 @@ const seo = (seoConfig: SEOConfig) => (config: Config): Config => {
         {
           name: 'title',
           type: 'text',
-          localized: true,
+          localized: false, //TODO: enable and fix localization
           admin: {
             components: {
               Field: (props) => getMetaTitleField({ ...props, seoConfig }),
@@ -37,7 +37,7 @@ const seo = (seoConfig: SEOConfig) => (config: Config): Config => {
         {
           name: 'description',
           type: 'textarea',
-          localized: true,
+          localized: false, //TODO: enable and fix localization
           admin: {
             components: {
               Field: (props) => getMetaDescriptionField({ ...props, seoConfig }),
@@ -48,7 +48,7 @@ const seo = (seoConfig: SEOConfig) => (config: Config): Config => {
           name: 'image',
           label: 'Meta Image',
           type: 'upload',
-          localized: true,
+          localized: false, //TODO: enable and fix localization
           relationTo: seoConfig?.uploadsCollection,
           admin: {
             description: 'Maximum upload file size: 12MB. Recommended file size for images is <500KB.',

--- a/yarn.lock
+++ b/yarn.lock
@@ -6986,10 +6986,10 @@ pause@0.0.1:
   resolved "https://registry.yarnpkg.com/pause/-/pause-0.0.1.tgz#1d408b3fdb76923b9543d96fb4c9dfd535d9cb5d"
   integrity sha1-HUCLP9t2kjuVQ9lvtMnf1TXZy10=
 
-payload@^0.17.0:
-  version "0.17.0"
-  resolved "https://registry.yarnpkg.com/payload/-/payload-0.17.0.tgz#192a44588b2bb98f16b10726544bd81cc0b19137"
-  integrity sha512-+UlgCoAUv44e2ehGN0qWBd/m0FulGSdvpupDScL4KNZjF1GXyXJeWHpZ+Su6+BGrweWlhp+0W1Ym7Fus8OMnYg==
+payload@^0.17.1:
+  version "0.17.1"
+  resolved "https://registry.yarnpkg.com/payload/-/payload-0.17.1.tgz#a0926feba7b60b00cb02ec307a432c676e082ed9"
+  integrity sha512-W1bOFu6ZF6TQ/yomeO4rGX03wKZtwxANhvgVwTPxO16q/Axm/Fap9F1l+o7zp56mHIi10au7eB+o07cOLwDaAA==
   dependencies:
     "@babel/cli" "^7.12.8"
     "@babel/core" "^7.11.6"


### PR DESCRIPTION
Localized fields don't work anyways for some reason, and disabling them fixes the error when saving the page and makes the SEO plugin work with payload 0.17.1.

This is the error when trying to publish a page with localization enabled:
```
[20:27:43] ERROR (payload): TypeError: Cannot read properties of undefined (reading 'reduce')
    at C:\Coding\GitHub\plugin-seo\demo\node_modules\payload\src\fields\hooks\beforeChange\promise.ts:129:68
    at C:\Coding\GitHub\plugin-seo\demo\node_modules\payload\src\fields\hooks\beforeChange\index.ts:59:42
    at Array.forEach (<anonymous>)
    at beforeChange (C:\Coding\GitHub\plugin-seo\demo\node_modules\payload\src\fields\hooks\beforeChange\index.ts:59:22)
    at runMicrotasks (<anonymous>)
    at processTicksAndRejections (node:internal/process/task_queues:96:5)
    at Payload.create (C:\Coding\GitHub\plugin-seo\demo\node_modules\payload\src\collections\operations\create.ts:147:29)
    at Payload.create (C:\Coding\GitHub\plugin-seo\demo\node_modules\payload\src\collections\requestHandlers\create.ts:14:17)
```