### PR TITLE
fix: provide locale on URL generation

### DIFF
--- a/demo/src/payload.config.ts
+++ b/demo/src/payload.config.ts
@@ -60,7 +60,7 @@ export default buildConfig({
       uploadsCollection: 'media',
       generateTitle: ({ doc }: any) => `Website.com — ${doc?.title?.value}`,
       generateDescription: ({ doc }: any) => doc?.excerpt?.value,
-      generateURL: ({ doc }: any) => `https://yoursite.com/${doc?.slug?.value || ''}`
+      generateURL: ({ doc, locale }: any) => `https://yoursite.com/${locale ? locale + "/" : ""}${doc?.slug?.value || ''}`
     }),
   ],
   typescript: {

--- a/src/ui/Preview.tsx
+++ b/src/ui/Preview.tsx
@@ -1,6 +1,7 @@
-import { useWatchForm } from 'payload/components/forms';
+import { useAllFormFields } from 'payload/components/forms';
 import React, { useEffect, useState } from 'react';
 import { Field } from 'payload/dist/admin/components/forms/Form/types';
+import { useLocale } from 'payload/components/utilities';
 import { PluginConfig } from '../types';
 
 type PreviewFieldWithProps = Field & {
@@ -13,7 +14,8 @@ export const Preview: React.FC<PreviewFieldWithProps | {}> = (props) => {
     }
   } = props as PreviewFieldWithProps || {}; // TODO: this typing is temporary until payload types are updated for custom field props;
 
-  const { fields } = useWatchForm();
+  const locale = useLocale();
+  const [fields] = useAllFormFields()
 
   const {
     'meta.title': {
@@ -29,7 +31,7 @@ export const Preview: React.FC<PreviewFieldWithProps | {}> = (props) => {
   useEffect(() => {
     const getHref = async () => {
       if (typeof generateURL === 'function' && !href) {
-        const newHref = await generateURL({ doc: { fields } })
+        const newHref = await generateURL({ doc: { fields }, locale })
         setHref(newHref);
       }
     }


### PR DESCRIPTION
First Payload PR 🥳 

## In this PR:

- Make sure the URL generation provides a `locale`
- Add a tiny demo to show it's working in the demo
- Remove a deprecated call to `useWatchForm` and replace it with `useAllFormFields` to match the other components