### PR TITLE
Conditionally show "Auto-Generate" items

### DIFF
--- a/src/fields/MetaDescription.tsx
+++ b/src/fields/MetaDescription.tsx
@@ -43,9 +43,9 @@ export const MetaDescription: React.FC<(TextareaFieldWithProps | {}) & {
     showError
   } = field;
 
-  const regenerateDescription = useCallback(() => {
-    const { generateDescription } = pluginConfig;
+  const {generateDescription} = pluginConfig
 
+  const regenerateDescription = useCallback(() => {
     const getDescription = async () => {
       let generatedDescription;
       if (typeof generateDescription === 'function') {
@@ -75,13 +75,14 @@ export const MetaDescription: React.FC<(TextareaFieldWithProps | {}) & {
       >
         <div>
           {label}
-          &nbsp;
-          &mdash;
-          &nbsp;
-          <button
-            onClick={regenerateDescription}
-            type="button"
-            style={{
+          { typeof generateDescription === 'function' && <>
+            &nbsp;
+            &mdash;
+            &nbsp;
+            <button
+              onClick={regenerateDescription}
+              type="button"
+              style={{
               padding: 0,
               background: 'none',
               border: 'none',
@@ -89,17 +90,18 @@ export const MetaDescription: React.FC<(TextareaFieldWithProps | {}) & {
               cursor: 'pointer',
               textDecoration: 'underline',
               color: 'currentcolor',
-            }}
-          >
-            Auto-generate
-          </button>
+              }}
+            >
+                Auto-generate
+            </button>
+          </>}
         </div>
         <div
           style={{
             color: '#9A9A9A',
           }}
         >
-          {`This should be between ${minLength} and ${maxLength} characters. Auto-generation will format a description using the page content. For help in writing quality meta descriptions, see `}
+          {`This should be between ${minLength} and ${maxLength} characters. ${typeof generateDescription === 'function' ? "Auto-generation will format a description using the page content. " : ""}For help in writing quality meta descriptions, see `}
           <a
             href="https://developers.google.com/search/docs/advanced/appearance/snippet#meta-descriptions"
             rel="noopener noreferrer"

--- a/src/fields/MetaImage.tsx
+++ b/src/fields/MetaImage.tsx
@@ -32,8 +32,8 @@ export const MetaImage: React.FC<UploadFieldWithProps | {}> = (props) => {
     showError,
   } = field;
 
+  const { generateImage } = pluginConfig;
   const regenerateImage = useCallback(() => {
-    const { generateImage } = pluginConfig;
     const getDescription = async () => {
       let generatedImage;
       if (typeof generateImage === 'function') {
@@ -77,31 +77,33 @@ export const MetaImage: React.FC<UploadFieldWithProps | {}> = (props) => {
       >
         <div>
           {label}
-          &nbsp;
-          &mdash;
-          &nbsp;
-          <button
-            onClick={regenerateImage}
-            type="button"
-            style={{
-              padding: 0,
-              background: 'none',
-              border: 'none',
-              backgroundColor: 'transparent',
-              cursor: 'pointer',
-              textDecoration: 'underline',
-              color: 'currentcolor',
-            }}
-          >
-            Auto-generate
-          </button>
+          { typeof generateImage === 'function' && <>
+            &nbsp;
+            &mdash;
+            &nbsp;
+            <button
+              onClick={regenerateImage}
+              type="button"
+              style={{
+                  padding: 0,
+                  background: 'none',
+                  border: 'none',
+                  backgroundColor: 'transparent',
+                  cursor: 'pointer',
+                  textDecoration: 'underline',
+                  color: 'currentcolor',
+              }}
+              >
+              Auto-generate
+            </button>
+          </>}
         </div>
         <div
           style={{
             color: '#9A9A9A',
           }}
         >
-          Auto-generation will retrieve the selected hero image.
+          {typeof generateImage === 'function' ? "Auto-generation will retrieve the selected hero image." : ""}
         </div>
       </div>
       <div

--- a/src/fields/MetaTitle.tsx
+++ b/src/fields/MetaTitle.tsx
@@ -41,8 +41,8 @@ export const MetaTitle: React.FC<TextFieldWithProps | {}> = (props) => {
     showError
   } = field;
 
+  const { generateTitle } = pluginConfig;
   const regenerateTitle = useCallback(() => {
-    const { generateTitle } = pluginConfig;
 
     const getTitle = async () => {
       let generatedTitle;
@@ -73,31 +73,33 @@ export const MetaTitle: React.FC<TextFieldWithProps | {}> = (props) => {
       >
         <div>
           {label}
-          &nbsp;
-          &mdash;
-          &nbsp;
-          <button
-            onClick={regenerateTitle}
-            type="button"
-            style={{
-              padding: 0,
-              background: 'none',
-              border: 'none',
-              backgroundColor: 'transparent',
-              cursor: 'pointer',
-              textDecoration: 'underline',
-              color: 'currentcolor',
-            }}
-          >
-            Auto-generate
-          </button>
+          { typeof generateTitle === 'function' && <>
+            &nbsp;
+            &mdash;
+            &nbsp;
+            <button
+              onClick={regenerateTitle}
+              type="button"
+              style={{
+                  padding: 0,
+                  background: 'none',
+                  border: 'none',
+                  backgroundColor: 'transparent',
+                  cursor: 'pointer',
+                  textDecoration: 'underline',
+                  color: 'currentcolor',
+              }}
+              >
+              Auto-generate
+            </button>
+          </> }
         </div>
         <div
           style={{
             color: '#9A9A9A',
           }}
         >
-          {`This should be between ${minLength} and ${maxLength} characters. Auto-generation will format a title using the page title. For help in writing quality meta titles, see `}
+          {`This should be between ${minLength} and ${maxLength} characters. ${typeof generateTitle === 'function' ? "Auto-generation will format a title using the page title. " : ""}For help in writing quality meta titles, see `}
           <a
             href="https://developers.google.com/search/docs/advanced/appearance/title-link#page-titles"
             rel="noopener noreferrer"


### PR DESCRIPTION
Fixes issue #34 

When no auto-generation functions are provided, auto-generate buttons will not be rendered. Also removes any reference to auto-generation from the field description.

All tested running locally.

First open-source contribution so please give me pointers if I've done things wrong!

Example with buttons and descriptions removed:
<img width="1891" alt="Screenshot 2023-02-27 at 10 57 41" src="https://user-images.githubusercontent.com/100475394/221546161-e5bddbee-377d-462a-873b-75986adefe79.png">
