### PR TITLE
fix: supports custom fields #41

### DIFF
--- a/demo/src/payload.config.ts
+++ b/demo/src/payload.config.ts
@@ -43,6 +43,13 @@ export default buildConfig({
       globals: ['settings'],
       tabbedUI: true,
       uploadsCollection: 'media',
+      fields: [
+        {
+          name: 'ogTitle',
+          type: 'text',
+          label: 'og:title',
+        },
+      ],
       generateTitle: ({ doc }: any) => `Website.com — ${doc?.title?.value}`,
       generateDescription: ({ doc }: any) => doc?.excerpt?.value,
       generateURL: ({ doc, locale }: any) =>

--- a/src/index.ts
+++ b/src/index.ts
@@ -66,6 +66,7 @@ const seo =
                 } as Field,
               ]
             : []),
+          ...(pluginConfig?.fields || []),
           {
             name: 'preview',
             label: 'Preview',

--- a/src/types.ts
+++ b/src/types.ts
@@ -12,7 +12,7 @@ export interface PluginConfig {
   collections?: string[]
   globals?: string[]
   uploadsCollection?: string
-  fields?: Array<Partial<Field>>
+  fields?: Field[]
   tabbedUI?: boolean
   generateTitle?: GenerateTitle
   generateDescription?: GenerateDescription


### PR DESCRIPTION
Fixes #41 by spreading custom fields through the `seo` field group. The `fields` property already existed, but it was incorrectly typed and not used.