### PR TITLE
feat: threads doc info through generation functions #53

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![NPM](https://img.shields.io/npm/v/@payloadcms/plugin-seo)](https://www.npmjs.com/package/@payloadcms/plugin-seo)
 
-A plugin for [Payload CMS](https://github.com/payloadcms/payload) to auto-generate SEO meta data based on the content of your documents.
+A plugin for [Payload](https://github.com/payloadcms/payload) to auto-generate SEO meta data based on the content of your documents.
 
 Core features:
 
@@ -94,7 +94,7 @@ export default config;
   ```js
   seo({
     ...
-    generateTitle: ({ doc, locale }) => `Website.com — ${doc?.title?.value}`,
+    generateTitle: ({ ...docInfo, doc, locale }) => `Website.com — ${doc?.title?.value}`,
   })
   ```
 
@@ -105,7 +105,7 @@ export default config;
   ```js
   seo({
     ...
-    generateDescription: ({ doc, locale }) => doc?.excerpt?.value
+    generateDescription: ({ ...docInfo, doc, locale }) => doc?.excerpt?.value
   })
   ```
 
@@ -116,7 +116,7 @@ export default config;
   ```js
   seo({
    ...
-   generateImage: ({ doc, locale }) => doc?.featuredImage?.value
+   generateImage: ({ ...docInfo, doc, locale }) => doc?.featuredImage?.value
   })
   ```
 
@@ -127,7 +127,7 @@ export default config;
   ```js
   seo({
     ...
-    generateURL: ({ doc, locale }) => `https://yoursite.com/${doc?.slug?.value}`
+    generateURL: ({ ...docInfo, doc, locale }) => `https://yoursite.com/${collection?.slug}/${doc?.slug?.value}`
   })
   ```
 

--- a/demo/src/payload.config.ts
+++ b/demo/src/payload.config.ts
@@ -50,7 +50,7 @@ export default buildConfig({
           label: 'og:title',
         },
       ],
-      generateTitle: ({ doc }: any) => `Website.com — ${doc?.title?.value}`,
+      generateTitle: (data: any) => `Website.com — ${data?.doc?.title?.value}`,
       generateDescription: ({ doc }: any) => doc?.excerpt?.value,
       generateURL: ({ doc, locale }: any) =>
         `https://yoursite.com/${locale ? locale + '/' : ''}${doc?.slug?.value || ''}`,

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.13",
   "homepage:": "https://payloadcms.com",
   "repository": "git@github.com:payloadcms/plugin-seo.git",
-  "description": "SEO plugin for Payload CMS",
+  "description": "SEO plugin for Payload",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "scripts": {
@@ -28,7 +28,6 @@
     "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
   },
   "devDependencies": {
-    "@types/escape-html": "^1.0.1",
     "@payloadcms/eslint-config": "^0.0.1",
     "@types/express": "^4.17.9",
     "@types/node": "18.11.3",

--- a/src/fields/MetaDescription.tsx
+++ b/src/fields/MetaDescription.tsx
@@ -2,7 +2,7 @@
 
 import React, { useCallback } from 'react'
 import { useAllFormFields, useField } from 'payload/components/forms'
-import { useLocale } from 'payload/components/utilities'
+import { useDocumentInfo, useLocale } from 'payload/components/utilities'
 import TextareaInput from 'payload/dist/admin/components/forms/field-types/Textarea/Input'
 import { FieldType, Options } from 'payload/dist/admin/components/forms/useField/types'
 import { TextareaField } from 'payload/dist/fields/config/types'
@@ -27,6 +27,7 @@ export const MetaDescription: React.FC<
 
   const locale = useLocale()
   const [fields] = useAllFormFields()
+  const docInfo = useDocumentInfo()
 
   const field: FieldType<string> = useField({
     label,
@@ -36,18 +37,20 @@ export const MetaDescription: React.FC<
 
   const { value, setValue, showError } = field
 
-  const regenerateDescription = useCallback(() => {
+  const regenerateDescription = useCallback(async () => {
     const { generateDescription } = pluginConfig
+    let generatedDescription
 
-    const getDescription = async () => {
-      let generatedDescription
-      if (typeof generateDescription === 'function') {
-        generatedDescription = await generateDescription({ doc: { ...fields }, locale })
-      }
-      setValue(generatedDescription)
+    if (typeof generateDescription === 'function') {
+      generatedDescription = await generateDescription({
+        ...docInfo,
+        doc: { ...fields },
+        locale,
+      })
     }
-    getDescription()
-  }, [fields, setValue, pluginConfig, locale])
+
+    setValue(generatedDescription)
+  }, [fields, setValue, pluginConfig, locale, docInfo])
 
   return (
     <div

--- a/src/fields/MetaImage.tsx
+++ b/src/fields/MetaImage.tsx
@@ -2,7 +2,7 @@
 
 import React, { useCallback } from 'react'
 import { useAllFormFields, useField } from 'payload/components/forms'
-import { useConfig, useLocale } from 'payload/components/utilities'
+import { useConfig, useDocumentInfo, useLocale } from 'payload/components/utilities'
 import UploadInput from 'payload/dist/admin/components/forms/field-types/Upload/Input'
 import { Props as UploadFieldType } from 'payload/dist/admin/components/forms/field-types/Upload/types'
 import { FieldType, Options } from 'payload/dist/admin/components/forms/useField/types'
@@ -21,22 +21,26 @@ export const MetaImage: React.FC<UploadFieldWithProps | {}> = props => {
 
   const field: FieldType<string> = useField(props as Options)
 
-  const [fields] = useAllFormFields()
   const locale = useLocale()
+  const [fields] = useAllFormFields()
+  const docInfo = useDocumentInfo()
 
   const { value, setValue, showError } = field
 
-  const regenerateImage = useCallback(() => {
+  const regenerateImage = useCallback(async () => {
     const { generateImage } = pluginConfig
-    const getDescription = async () => {
-      let generatedImage
-      if (typeof generateImage === 'function') {
-        generatedImage = await generateImage({ doc: { ...fields }, locale })
-      }
-      setValue(generatedImage)
+    let generatedImage
+
+    if (typeof generateImage === 'function') {
+      generatedImage = await generateImage({
+        ...docInfo,
+        doc: { ...fields },
+        locale,
+      })
     }
-    getDescription()
-  }, [fields, setValue, pluginConfig, locale])
+
+    setValue(generatedImage)
+  }, [fields, setValue, pluginConfig, locale, docInfo])
 
   const hasImage = Boolean(value)
 

--- a/src/fields/MetaTitle.tsx
+++ b/src/fields/MetaTitle.tsx
@@ -2,7 +2,7 @@
 
 import React, { useCallback } from 'react'
 import { useAllFormFields, useField } from 'payload/components/forms'
-import { useLocale } from 'payload/components/utilities'
+import { useDocumentInfo, useLocale } from 'payload/components/utilities'
 import TextInputField from 'payload/dist/admin/components/forms/field-types/Text/Input'
 import { Props as TextFieldType } from 'payload/dist/admin/components/forms/field-types/Text/types'
 import { FieldType as FieldType, Options } from 'payload/dist/admin/components/forms/useField/types'
@@ -29,21 +29,24 @@ export const MetaTitle: React.FC<TextFieldWithProps | {}> = props => {
 
   const locale = useLocale()
   const [fields] = useAllFormFields()
+  const docInfo = useDocumentInfo()
 
   const { value, setValue, showError } = field
 
-  const regenerateTitle = useCallback(() => {
+  const regenerateTitle = useCallback(async () => {
     const { generateTitle } = pluginConfig
+    let generatedTitle
 
-    const getTitle = async () => {
-      let generatedTitle
-      if (typeof generateTitle === 'function') {
-        generatedTitle = await generateTitle({ doc: { ...fields }, locale })
-      }
-      setValue(generatedTitle)
+    if (typeof generateTitle === 'function') {
+      generatedTitle = await generateTitle({
+        ...docInfo,
+        doc: { ...fields },
+        locale,
+      })
     }
-    getTitle()
-  }, [fields, setValue, pluginConfig, locale])
+
+    setValue(generatedTitle)
+  }, [fields, setValue, pluginConfig, locale, docInfo])
 
   return (
     <div

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,12 +1,24 @@
+import type { ContextType } from 'payload/dist/admin/components/utilities/DocumentInfo/types'
 import type { Field } from 'payload/dist/fields/config/types'
 
-export type GenerateTitle = <T = any>(args: { doc: T; locale?: string }) => string | Promise<string>
-export type GenerateDescription = <T = any>(args: {
-  doc: T
-  locale?: string
-}) => string | Promise<string>
-export type GenerateImage = <T = any>(args: { doc: T; locale?: string }) => string | Promise<string>
-export type GenerateURL = <T = any>(args: { doc: T; locale?: string }) => string | Promise<string>
+export type GenerateTitle = <T = any>(
+  args: ContextType & { doc: T; locale?: string },
+) => string | Promise<string>
+
+export type GenerateDescription = <T = any>(
+  args: ContextType & {
+    doc: T
+    locale?: string
+  },
+) => string | Promise<string>
+
+export type GenerateImage = <T = any>(
+  args: ContextType & { doc: T; locale?: string },
+) => string | Promise<string>
+
+export type GenerateURL = <T = any>(
+  args: ContextType & { doc: T; locale?: string },
+) => string | Promise<string>
 
 export interface PluginConfig {
   collections?: string[]

--- a/src/ui/Preview.tsx
+++ b/src/ui/Preview.tsx
@@ -2,7 +2,7 @@
 
 import React, { useEffect, useState } from 'react'
 import { useAllFormFields } from 'payload/components/forms'
-import { useLocale } from 'payload/components/utilities'
+import { useDocumentInfo, useLocale } from 'payload/components/utilities'
 import { Field } from 'payload/dist/admin/components/forms/Form/types'
 
 import { PluginConfig } from '../types'
@@ -10,6 +10,7 @@ import { PluginConfig } from '../types'
 type PreviewFieldWithProps = Field & {
   pluginConfig: PluginConfig
 }
+
 export const Preview: React.FC<PreviewFieldWithProps | {}> = props => {
   const {
     pluginConfig: { generateURL },
@@ -17,6 +18,7 @@ export const Preview: React.FC<PreviewFieldWithProps | {}> = props => {
 
   const locale = useLocale()
   const [fields] = useAllFormFields()
+  const docInfo = useDocumentInfo()
 
   const {
     'meta.title': { value: metaTitle } = {} as Field,
@@ -28,12 +30,17 @@ export const Preview: React.FC<PreviewFieldWithProps | {}> = props => {
   useEffect(() => {
     const getHref = async () => {
       if (typeof generateURL === 'function' && !href) {
-        const newHref = await generateURL({ doc: { fields }, locale })
+        const newHref = await generateURL({
+          ...docInfo,
+          doc: { fields },
+          locale,
+        })
+
         setHref(newHref)
       }
     }
     getHref()
-  }, [generateURL, fields, href, locale])
+  }, [generateURL, fields, href, locale, docInfo])
 
   return (
     <div>

--- a/yarn.lock
+++ b/yarn.lock
@@ -607,11 +607,6 @@
   dependencies:
     "@types/node" "*"
 
-"@types/escape-html@^1.0.1":
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/@types/escape-html/-/escape-html-1.0.2.tgz#072b7b13784fb3cee9c2450c22f36405983f5e3c"
-  integrity sha512-gaBLT8pdcexFztLSPRtriHeXY/Kn4907uOCZ4Q3lncFBkheAWOuNt53ypsF8szgxbEJ513UeBzcf4utN0EzEwA==
-
 "@types/eslint-scope@^3.7.3":
   version "3.7.4"
   resolved "https://registry.yarnpkg.com/@types/eslint-scope/-/eslint-scope-3.7.4.tgz#37fc1223f0786c39627068a12e94d6e6fc61de16"


### PR DESCRIPTION
Closes #53 by threading the result of `useDocumentInfo` through the generation function like `generateMetaTitle`. Does so  in a non-breaking way by simply adding properties onto the existing arguments. Updates types and README accordingly.